### PR TITLE
YOLOv8 segmentation trained on data v3

### DIFF
--- a/notebooks/local_training_v3.ipynb
+++ b/notebooks/local_training_v3.ipynb
@@ -1,0 +1,8968 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "GNJfo6unYms0"
+   },
+   "source": [
+    "### **Training** ###\n",
+    "This notebook trains the YOLOv8 segmentation model to detect a new rooftop class. We considered the available YOLO configurations—nano, small, medium, large, and xl. While the larger sizes generally yield better results, they come with higher computational demands. To balance performance and computational expense, we chose the small YOLO model.\n",
+    "\n",
+    "The training datasets were derived from the RAMP dataset and prepared using the preprocessing notebook. To optimize the model results, we trained YOLO using data version 1, 2, and 3. Each data version was successively pruned (V3, V2, .. V0), meaning V3 was pruned from V2 and so on to V0 so that each version contains the prunings from all of the previous.\n",
+    "\n",
+    "RAMP-DATA-V0: 'Full Dataset' is 100k image-label pairs converted from RAMP's TIF-GEOJSON formats within 22 regional folders and stored in train-val-test folders with a 70-15-15 split; zipped at 15.2 GB downloaded from Source Cooperative.\n",
+    "\n",
+    "YOLO-DATA-V1: 'Preprocessing' was a process that resulted in 83k image-label pairs in JPG-TXT formats from 20 regions, zipped at 3.5 GB. We pruned 17k images from V0, reducing the background images from 18% to 5%. Shanghai and Paris regions were removed due to image format issues. A minimal manual review discovered a few labeling issues (n=38), ensuring the highest data quality.\n",
+    "\n",
+    "YOLO-DATA-V2: 'Pruning #2' resulted in 79k image-label pairs in JPG-TXT formats from 20 regions, zipped at 3.3 GB. We scored and analyzed inference results from the YOLO model trained on DATA-V1. The analysis revealed double the expected number of left-tail outliers. To improve labeling accuracy, we removed 4k outliers, assuming that most of these labels were errors.\n",
+    "\n",
+    "YOLO-DATA-V3: 'Zoom 19' resulted in 55k image-label pairs in JPG-TXT formats from 20 regions, zipped at 2.4 GB. We extracted the x and y scales from the TIF files and found the range to be between 0.3 and 0.52 meters per pixel, with 70% between 0.3 and 0.4. To test the effect of training near Zoom 19, which equates to 0.3 meters per pixel, we removed all image labels with scales greater than 0.4.\n",
+    "\n",
+    "To relieve the time constraints, we recommend training with a GPU. Google Colab's High-RAM T4 can train 100 epochs in 15 hours using a large batch size and cache enabled to minimize disk I/O. Using a 2023 laptop with a CPU, training YOLO for 100 epochs takes about 2.4 weeks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "C7HcnWcCYms1"
+   },
+   "outputs": [],
+   "source": [
+    "!pip3 install -q ultralytics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "Z-ZcgCSxm7AA"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "Looking in indexes: https://download.pytorch.org/whl/cu116\n",
+      "Requirement already satisfied: torch in ./.local/lib/python3.10/site-packages (2.5.0)\n",
+      "Requirement already satisfied: torchvision in ./.local/lib/python3.10/site-packages (0.20.0)\n",
+      "Requirement already satisfied: torchaudio in ./.local/lib/python3.10/site-packages (2.5.0+cu118)\n",
+      "Requirement already satisfied: jinja2 in ./.local/lib/python3.10/site-packages (from torch) (3.1.4)\n",
+      "Requirement already satisfied: triton==3.1.0 in ./.local/lib/python3.10/site-packages (from torch) (3.1.0)\n",
+      "Requirement already satisfied: nvidia-cuda-runtime-cu12==12.4.127 in ./.local/lib/python3.10/site-packages (from torch) (12.4.127)\n",
+      "Requirement already satisfied: nvidia-cusparse-cu12==12.3.1.170 in ./.local/lib/python3.10/site-packages (from torch) (12.3.1.170)\n",
+      "Requirement already satisfied: nvidia-cudnn-cu12==9.1.0.70 in ./.local/lib/python3.10/site-packages (from torch) (9.1.0.70)\n",
+      "Requirement already satisfied: nvidia-cublas-cu12==12.4.5.8 in ./.local/lib/python3.10/site-packages (from torch) (12.4.5.8)\n",
+      "Requirement already satisfied: fsspec in ./.local/lib/python3.10/site-packages (from torch) (2024.10.0)\n",
+      "Requirement already satisfied: nvidia-curand-cu12==10.3.5.147 in ./.local/lib/python3.10/site-packages (from torch) (10.3.5.147)\n",
+      "Requirement already satisfied: nvidia-nccl-cu12==2.21.5 in ./.local/lib/python3.10/site-packages (from torch) (2.21.5)\n",
+      "Requirement already satisfied: filelock in /usr/lib/python3/dist-packages (from torch) (3.6.0)\n",
+      "Requirement already satisfied: networkx in ./.local/lib/python3.10/site-packages (from torch) (3.4.2)\n",
+      "Requirement already satisfied: nvidia-cuda-cupti-cu12==12.4.127 in ./.local/lib/python3.10/site-packages (from torch) (12.4.127)\n",
+      "Requirement already satisfied: nvidia-cufft-cu12==11.2.1.3 in ./.local/lib/python3.10/site-packages (from torch) (11.2.1.3)\n",
+      "Requirement already satisfied: nvidia-cuda-nvrtc-cu12==12.4.127 in ./.local/lib/python3.10/site-packages (from torch) (12.4.127)\n",
+      "Requirement already satisfied: sympy==1.13.1 in ./.local/lib/python3.10/site-packages (from torch) (1.13.1)\n",
+      "Requirement already satisfied: nvidia-nvjitlink-cu12==12.4.127 in ./.local/lib/python3.10/site-packages (from torch) (12.4.127)\n",
+      "Requirement already satisfied: typing-extensions>=4.8.0 in ./.local/lib/python3.10/site-packages (from torch) (4.12.2)\n",
+      "Requirement already satisfied: nvidia-nvtx-cu12==12.4.127 in ./.local/lib/python3.10/site-packages (from torch) (12.4.127)\n",
+      "Requirement already satisfied: nvidia-cusolver-cu12==11.6.1.9 in ./.local/lib/python3.10/site-packages (from torch) (11.6.1.9)\n",
+      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in ./.local/lib/python3.10/site-packages (from sympy==1.13.1->torch) (1.3.0)\n",
+      "Requirement already satisfied: numpy in ./.local/lib/python3.10/site-packages (from torchvision) (2.1.2)\n",
+      "Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in ./.local/lib/python3.10/site-packages (from torchvision) (11.0.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in ./.local/lib/python3.10/site-packages (from jinja2->torch) (3.0.2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu116"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "_xawTrLwlm7F"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CUDA is available. Using GPU for training.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "\n",
+    "#Use GPU is avalaibe\n",
+    "if torch.cuda.is_available():\n",
+    "  print(\"CUDA is available. Using GPU for training.\")\n",
+    "  device = torch.device(\"cuda\")\n",
+    "else:\n",
+    "  print(\"CUDA is not available. Using CPU for training.\")\n",
+    "  device = torch.device(\"cpu\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "1aik3Y-tYms2"
+   },
+   "outputs": [],
+   "source": [
+    "from ultralytics import YOLO\n",
+    "import os\n",
+    "import yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "zKm1dhv5ahb3"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".python_history 45\n",
+      "yolov8m-seg.pt 54921020\n",
+      "yolov8x-seg.pt 144101612\n",
+      ".sudo_as_admin_successful 0\n",
+      "data3_ramp_data_yolo_iou_scale.zip 2419400988\n",
+      "yolov8n-seg.pt 7071756\n",
+      "data1_ramp_data_yolo.zip 3508121128\n",
+      ".bash_history 6154\n",
+      "yolov8s-seg.pt 23914764\n",
+      ".motd_shown 0\n",
+      "cuda-keyring_1.1-1_all.deb 4328\n",
+      "args_500e.yaml 504\n",
+      "yolo11n.pt 5613764\n",
+      ".profile 807\n",
+      "yolov8l-seg.pt 92417004\n",
+      ".bash_logout 220\n",
+      ".rediscli_history 12\n",
+      "args_500e_tuned.yaml 516\n",
+      "Copy_of_training.ipynb 15697\n",
+      ".bashrc 3771\n",
+      "yolov8_-seg.zip 298131335\n",
+      "data.yaml 99\n"
+     ]
+    }
+   ],
+   "source": [
+    "for entry in os.scandir('.'):\n",
+    "    if entry.is_file():\n",
+    "        print(entry.name,entry.stat().st_size)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "XBIHxuVYYms2"
+   },
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Which dataset do you want to download? Enter 'v1', 'v2', or 'v3':  v3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "unzipping data3_ramp_data_yolo.zip\n",
+      "Unzipping models...\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_choice = input(\"Which dataset do you want to download? Enter 'v1', 'v2', or 'v3': \")\n",
+    "\n",
+    "if data_choice.lower() == 'v1':\n",
+    "    print(\"\\nunzipping data1_ramp_data_yolo.zip\")\n",
+    "    # !unzip -q -o data3*.zip\n",
+    "elif data_choice.lower() == 'v2':\n",
+    "    print(\"Invalid input.\")\n",
+    "elif data_choice.lower() == 'v3':\n",
+    "    print(\"\\nunzipping data3_ramp_data_yolo.zip\")\n",
+    "    # !unzip -q -o data3*.zip\n",
+    "else:\n",
+    "    print(\"Invalid input.\")\n",
+    "\n",
+    "print('Unzipping models...')\n",
+    "# !unzip -q -o yolov8_-seg.zip\n",
+    "\n",
+    "# # Download and unzip the specified data version\n",
+    "# if data_choice.lower() == 'v1':\n",
+    "#     print(\"\\nDownloading and unzipping v1...\")\n",
+    "#     !gdown --fuzzy https://drive.google.com/file/d/1iosxGOyBXNXoAdvdxIR7DTSWKRVLijqa/view?usp=sharing\n",
+    "#     !unzip -q data1*.zip\n",
+    "# elif data_choice.lower() == 'v2':\n",
+    "#     print(\"\\nDownloading and unzipping v2...\")\n",
+    "#     !gdown --fuzzy https://drive.google.com/file/d/1zXwvKLxzzOBp1bQ67nqfOgM55BI6sHho/view?usp=sharing\n",
+    "#     !unzip -q data2*.zip\n",
+    "# elif data_choice.lower() == 'v3':\n",
+    "#     print(\"\\nDownloading and unzipping v3...\")\n",
+    "#     !gdown --fuzzy https://drive.google.com/file/d/1K-jaOylXjukvCC6Uu8Ms2e7LxfL0-qWg/view?usp=sharing\n",
+    "#     !unzip -q data3*.zip\n",
+    "# else:\n",
+    "#     print(\"Invalid input.\")\n",
+    "\n",
+    "# Download and unzip models if not found.\n",
+    "# if not os.path.exists('yolov8s-seg.pt'):\n",
+    "#     print('\\nDownloading and unzipping YOLOv8 models...')\n",
+    "#     !gdown --fuzzy https://drive.google.com/file/d/189U5fTomw3-QPjPpkppiXVSKa-sVIQIl/view?usp=sharing\n",
+    "#     print('Unzipping models...')\n",
+    "#     !unzip -q yolov8_-seg.zip\n",
+    "#     print('Models downloaded')\n",
+    "# else:\n",
+    "#     print('\\nModels already downloaded')\n",
+    "\n",
+    "# Download the training arguments\n",
+    "# print('\\nDownloading training arguments...')\n",
+    "# !gdown --fuzzy https://drive.google.com/file/d/13KLv4ywEVNVQHWhahIapSDDEzJWcAmT_/view?usp=sharing\n",
+    "# !gdown --fuzzy https://drive.google.com/file/d/1_N8H6akiKqFwezDjqfjVuXDvuP6zJZGP/view?usp=sharing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "R4yCQSsdYms3"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing the data file with path=/home/omran/ramp_data_yolo_iou_scale\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Write the YAML file for YOLO that contains the class names and train/val paths\n",
+    "YAML = 'data.yaml'\n",
+    "\n",
+    "# Set the path based on the version of the dataset\n",
+    "if data_choice == 'v1':\n",
+    "    path = f'{os.getcwd()}/ramp_data_yolo'\n",
+    "elif data_choice == 'v2':\n",
+    "    path = f'{os.getcwd()}/ramp_data_yolo_iou'\n",
+    "elif data_choice == 'v3':\n",
+    "    path = f'{os.getcwd()}/ramp_data_yolo_iou_scale'\n",
+    "\n",
+    "# Set the attribute for the YAML file\n",
+    "attr = {\n",
+    "    'path': path,\n",
+    "    'train': 'train/images',\n",
+    "    'val': 'val/images',\n",
+    "    'names': {\n",
+    "        0: 'rooftop'\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "# Print the path\n",
+    "print(f'Writing the data file with path={path}')\n",
+    "\n",
+    "# Write the file\n",
+    "with open(YAML, 'w') as f:\n",
+    "    yaml.dump(attr, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "UK9WryfghhqY"
+   },
+   "outputs": [],
+   "source": [
+    "# !pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "ny2nFtPyQmpi"
+   },
+   "outputs": [],
+   "source": [
+    "# # HIGHLY RECOMMENDED if your training is of a long duration\n",
+    "# # Connect to Google Drive so that if session is terminated you can resume\n",
+    "# from google.colab import drive\n",
+    "\n",
+    "# # Uncomment if needed\n",
+    "# drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "id": "b-GYo9bNYms3",
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Do you want to start or resume training? Enter 'new' for new training or 'resume' to resume training:  resume\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resuming training...\n",
+      "Loading model from ///home/omran/yolov8s-seg_data_v3/weights/last.pt\n",
+      "Ultralytics 8.3.24 🚀 Python-3.10.6 torch-2.5.0+cu124 CUDA:0 (NVIDIA GeForce RTX 3060 Laptop GPU, 6144MiB)\n",
+      "\u001b[34m\u001b[1mengine/trainer: \u001b[0mtask=segment, mode=train, model=/home/omran/yolov8s-seg_data_v3/weights/last.pt, data=data.yaml, epochs=500, time=None, patience=500, batch=64, imgsz=256, save=True, save_period=-1, cache=disk, device=cuda, workers=8, project=/, name=yolov8s-seg_data_v34, exist_ok=False, pretrained=True, optimizer=auto, verbose=True, seed=0, deterministic=True, single_cls=False, rect=False, cos_lr=False, close_mosaic=10, resume=/home/omran/yolov8s-seg_data_v3/weights/last.pt, amp=True, fraction=1.0, profile=False, freeze=None, multi_scale=False, overlap_mask=False, mask_ratio=4, dropout=0.0, val=True, split=val, save_json=False, save_hybrid=False, conf=None, iou=0.7, max_det=300, half=False, dnn=False, plots=True, source=None, vid_stride=1, stream_buffer=False, visualize=False, augment=False, agnostic_nms=False, classes=None, retina_masks=False, embed=None, show=False, save_frames=False, save_txt=False, save_conf=False, save_crop=False, show_labels=True, show_conf=True, show_boxes=True, line_width=None, format=torchscript, keras=False, optimize=False, int8=False, dynamic=False, simplify=True, opset=None, workspace=4, nms=False, lr0=0.00854, lrf=0.01232, momentum=0.95275, weight_decay=0.00058, warmup_epochs=3.82177, warmup_momentum=0.81423, warmup_bias_lr=0.0, box=7.48109, cls=0.775, dfl=1.5, pose=12.0, kobj=1.0, label_smoothing=0.0, nbs=64, hsv_h=0.01269, hsv_s=0.68143, hsv_v=0.27, degrees=15.75, translate=0, scale=0, shear=0, perspective=0.0, flipud=0.5, fliplr=0.255, bgr=0.0, mosaic=0, mixup=0.0, copy_paste=0.0, copy_paste_mode=flip, auto_augment=randaugment, erasing=0, crop_fraction=1.0, cfg=None, tracker=botsort.yaml, save_dir=/home/omran/yolov8s-seg_data_v34\n",
+      "\n",
+      "                   from  n    params  module                                       arguments                     \n",
+      "  0                  -1  1       928  ultralytics.nn.modules.conv.Conv             [3, 32, 3, 2]                 \n",
+      "  1                  -1  1     18560  ultralytics.nn.modules.conv.Conv             [32, 64, 3, 2]                \n",
+      "  2                  -1  1     29056  ultralytics.nn.modules.block.C2f             [64, 64, 1, True]             \n",
+      "  3                  -1  1     73984  ultralytics.nn.modules.conv.Conv             [64, 128, 3, 2]               \n",
+      "  4                  -1  2    197632  ultralytics.nn.modules.block.C2f             [128, 128, 2, True]           \n",
+      "  5                  -1  1    295424  ultralytics.nn.modules.conv.Conv             [128, 256, 3, 2]              \n",
+      "  6                  -1  2    788480  ultralytics.nn.modules.block.C2f             [256, 256, 2, True]           \n",
+      "  7                  -1  1   1180672  ultralytics.nn.modules.conv.Conv             [256, 512, 3, 2]              \n",
+      "  8                  -1  1   1838080  ultralytics.nn.modules.block.C2f             [512, 512, 1, True]           \n",
+      "  9                  -1  1    656896  ultralytics.nn.modules.block.SPPF            [512, 512, 5]                 \n",
+      " 10                  -1  1         0  torch.nn.modules.upsampling.Upsample         [None, 2, 'nearest']          \n",
+      " 11             [-1, 6]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           \n",
+      " 12                  -1  1    591360  ultralytics.nn.modules.block.C2f             [768, 256, 1]                 \n",
+      " 13                  -1  1         0  torch.nn.modules.upsampling.Upsample         [None, 2, 'nearest']          \n",
+      " 14             [-1, 4]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           \n",
+      " 15                  -1  1    148224  ultralytics.nn.modules.block.C2f             [384, 128, 1]                 \n",
+      " 16                  -1  1    147712  ultralytics.nn.modules.conv.Conv             [128, 128, 3, 2]              \n",
+      " 17            [-1, 12]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           \n",
+      " 18                  -1  1    493056  ultralytics.nn.modules.block.C2f             [384, 256, 1]                 \n",
+      " 19                  -1  1    590336  ultralytics.nn.modules.conv.Conv             [256, 256, 3, 2]              \n",
+      " 20             [-1, 9]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           \n",
+      " 21                  -1  1   1969152  ultralytics.nn.modules.block.C2f             [768, 512, 1]                 \n",
+      " 22        [15, 18, 21]  1   2770931  ultralytics.nn.modules.head.Segment          [1, 32, 128, [128, 256, 512]] \n",
+      "YOLOv8s-seg summary: 261 layers, 11,790,483 parameters, 11,790,467 gradients, 42.7 GFLOPs\n",
+      "\n",
+      "Transferred 417/417 items from pretrained weights\n",
+      "Freezing layer 'model.22.dfl.conv.weight'\n",
+      "\u001b[34m\u001b[1mAMP: \u001b[0mrunning Automatic Mixed Precision (AMP) checks...\n",
+      "\u001b[34m\u001b[1mAMP: \u001b[0mchecks passed ✅\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mtrain: \u001b[0mScanning /home/omran/ramp_data_yolo_iou_scale/train/labels.cache... 38662 images, 2211 backgrounds, 0 corrupt: 10\u001b[0m\n",
+      "\u001b[34m\u001b[1mtrain: \u001b[0mCaching images (7.1GB Disk): 100%|██████████| 38662/38662 [00:02<00:00, 14265.39it/s]\u001b[0m\n",
+      "\u001b[34m\u001b[1mval: \u001b[0mScanning /home/omran/ramp_data_yolo_iou_scale/val/labels.cache... 8363 images, 480 backgrounds, 0 corrupt: 100%|███\u001b[0m\n",
+      "\u001b[34m\u001b[1mval: \u001b[0mCaching images (1.5GB Disk): 100%|██████████| 8363/8363 [00:00<00:00, 14970.05it/s]\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plotting labels to /home/omran/yolov8s-seg_data_v34/labels.jpg... \n",
+      "\u001b[34m\u001b[1moptimizer:\u001b[0m 'optimizer=auto' found, ignoring 'lr0=0.00854' and 'momentum=0.95275' and determining best 'optimizer', 'lr0' and 'momentum' automatically... \n",
+      "\u001b[34m\u001b[1moptimizer:\u001b[0m SGD(lr=0.01, momentum=0.9) with parameter groups 66 weight(decay=0.0), 77 weight(decay=0.00058), 76 bias(decay=0.0)\n",
+      "Resuming training /home/omran/yolov8s-seg_data_v3/weights/last.pt from epoch 3 to 500 total epochs\n",
+      "Image sizes 256 train, 256 val\n",
+      "Using 8 dataloader workers\n",
+      "Logging results to \u001b[1m/home/omran/yolov8s-seg_data_v34\u001b[0m\n",
+      "Starting training for 500 epochs...\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "      3/500      3.94G      1.294      1.996      1.469      1.072         62        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.659      0.598      0.651      0.384      0.657      0.587      0.637      0.341\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "      4/500      3.95G      1.331      2.045      1.516      1.092         48        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.685      0.603      0.667      0.394      0.678      0.587      0.651       0.35\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "      5/500      3.93G      1.314      2.012      1.492      1.092         90        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.697      0.615      0.681      0.411      0.694      0.597      0.663       0.36\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "      6/500      3.91G      1.274      1.947      1.439      1.078         77        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.728      0.639       0.72      0.446      0.725      0.632      0.714      0.406\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "      7/500      3.89G       1.25      1.905      1.409      1.069         59        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.721       0.64      0.714      0.445      0.718       0.63      0.704      0.397\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "      8/500      4.14G      1.231      1.875      1.386      1.062         84        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.739      0.643      0.729      0.462      0.736      0.634      0.719      0.408\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "      9/500      4.33G      1.217      1.851      1.369      1.057        105        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.739      0.657      0.737       0.47      0.736      0.647      0.726      0.418\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     10/500      4.09G      1.211       1.84      1.356      1.055         64        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.743      0.664      0.745      0.477      0.739      0.651       0.73      0.419\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     11/500      3.92G      1.202      1.821      1.346      1.051         93        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.749      0.666       0.75      0.483      0.745      0.655      0.737      0.425\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     12/500      3.86G      1.196      1.808      1.338      1.049         88        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.754       0.67      0.755      0.489      0.749      0.659      0.743      0.431\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     13/500      3.98G      1.189      1.801       1.33      1.045         73        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.751      0.673      0.755       0.49      0.749      0.663      0.745      0.434\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     14/500      3.85G      1.185      1.793      1.323      1.044        158        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.756      0.673      0.759      0.494      0.752      0.662      0.747      0.435\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     15/500      4.11G      1.181      1.783       1.32      1.042         62        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.759      0.675      0.761      0.496      0.756      0.662      0.748      0.438\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     16/500      3.98G      1.177       1.78      1.315       1.04        110        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.761      0.678      0.765        0.5      0.757      0.666      0.753      0.441\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     17/500      3.85G      1.174      1.772       1.31      1.039         51        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.762      0.681      0.767      0.502      0.757       0.67      0.756      0.445\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     18/500      4.01G      1.173      1.771      1.306      1.039         59        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.763      0.683      0.769      0.505      0.759      0.671      0.757      0.445\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     19/500      4.43G      1.171      1.765      1.304      1.037         78        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.764      0.683       0.77      0.507       0.76      0.672      0.758      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     20/500      4.05G      1.166      1.761      1.297      1.035         92        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.764      0.687      0.772      0.508      0.762      0.674       0.76      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     21/500      3.78G      1.163      1.756      1.295      1.035         78        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.686      0.773       0.51      0.763      0.676      0.762       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     22/500      4.01G      1.163      1.753      1.294      1.034         97        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.766      0.689      0.774       0.51      0.763      0.677      0.762       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     23/500      3.77G      1.159      1.745      1.291      1.032        105        256: 100%|██████████| 605/605 [07:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769       0.69      0.776      0.512      0.765      0.677      0.764      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     24/500      4.16G      1.158      1.746      1.288      1.032         57        256: 100%|██████████| 605/605 [07:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77       0.69      0.776      0.513      0.764      0.678      0.764      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     25/500      4.16G      1.156      1.744      1.287      1.032         94        256: 100%|██████████| 605/605 [10:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771       0.69      0.777      0.514      0.766      0.679      0.765      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     26/500      4.16G      1.156      1.739      1.282      1.031         64        256: 100%|██████████| 605/605 [08:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.691      0.778      0.514      0.765       0.68      0.766      0.454\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     27/500      3.83G      1.154      1.737      1.282      1.031        115        256: 100%|██████████| 605/605 [08:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.779      0.515      0.766       0.68      0.766      0.454\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     28/500      3.86G      1.152      1.733      1.278      1.029         80        256: 100%|██████████| 605/605 [08:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.693      0.779      0.516      0.766      0.681      0.767      0.454\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     29/500      3.94G       1.15      1.734      1.278       1.03         92        256: 100%|██████████| 605/605 [20:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.693      0.779      0.516      0.769       0.68      0.767      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     30/500      3.69G      1.149      1.734      1.277      1.028        127        256: 100%|██████████| 605/605 [12:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.694       0.78      0.517      0.768       0.68      0.767      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     31/500      4.06G      1.149      1.729      1.275      1.028         61        256: 100%|██████████| 605/605 [06:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.694       0.78      0.517      0.767      0.682      0.767      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     32/500      4.21G      1.149      1.727      1.275      1.029        134        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.694       0.78      0.517      0.766      0.682      0.768      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     33/500      3.85G      1.147      1.726      1.274      1.028         61        256: 100%|██████████| 605/605 [09:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.781      0.518      0.767      0.683      0.768      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     34/500      3.63G      1.146      1.727      1.271      1.028         74        256: 100%|██████████| 605/605 [08:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.781      0.518      0.766      0.683      0.768      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     35/500      3.78G      1.146      1.723      1.272      1.028        112        256: 100%|██████████| 605/605 [07:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.781      0.518      0.766      0.683      0.768      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     36/500      3.96G      1.144      1.719       1.27      1.027         45        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.781      0.518      0.767      0.683      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     37/500      3.84G      1.146      1.721      1.269      1.026         57        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.782      0.519      0.767      0.683      0.769      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     38/500      4.06G      1.143      1.721      1.268      1.025        125        256: 100%|██████████| 605/605 [07:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.782      0.519      0.767      0.683      0.769      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     39/500      3.75G      1.143      1.719      1.265      1.026         82        256: 100%|██████████| 605/605 [06:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.695      0.782      0.519      0.767      0.683      0.769      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     40/500       4.3G      1.143      1.716      1.265      1.025         77        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.696      0.782       0.52      0.768      0.684      0.769      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     41/500      4.15G      1.142      1.713      1.267      1.025         99        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.696      0.782       0.52      0.767      0.684       0.77      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     42/500      3.97G       1.14      1.712      1.264      1.024         52        256: 100%|██████████| 605/605 [05:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.696      0.782       0.52      0.767      0.684       0.77      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     43/500         4G       1.14      1.713      1.265      1.025        112        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.695      0.782       0.52      0.769      0.683       0.77      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     44/500      3.83G       1.14      1.713      1.264      1.024        112        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.695      0.783       0.52      0.768      0.684       0.77      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     45/500      4.02G       1.14       1.71      1.262      1.023         50        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.695      0.783       0.52      0.769      0.683       0.77      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     46/500      3.74G      1.139      1.711      1.262      1.024         89        256: 100%|██████████| 605/605 [07:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.696      0.783      0.521      0.769      0.684       0.77      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     47/500      3.83G      1.137      1.707       1.26      1.023         55        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.696      0.783      0.521      0.768      0.685      0.771      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     48/500      4.52G      1.137      1.706      1.258      1.022        102        256: 100%|██████████| 605/605 [06:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.783      0.521      0.768      0.685      0.771      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     49/500      3.98G      1.136      1.708      1.258      1.022         52        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.783      0.521      0.768      0.685      0.771      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     50/500      4.02G      1.137      1.707       1.26      1.021         79        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.697      0.783      0.521      0.768      0.685      0.771      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     51/500         4G      1.138      1.707       1.26      1.023         50        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.697      0.783      0.521      0.768      0.685      0.771      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     52/500      4.01G      1.135      1.704      1.256      1.021         80        256: 100%|██████████| 605/605 [06:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.697      0.783      0.522      0.768      0.685      0.771      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     53/500         4G      1.134        1.7      1.256       1.02         52        256: 100%|██████████| 605/605 [07:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.697      0.784      0.522      0.769      0.686      0.771      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     54/500      3.58G      1.135      1.701      1.255      1.021         44        256: 100%|██████████| 605/605 [15:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.698      0.784      0.522      0.769      0.686      0.771      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     55/500      3.93G      1.133        1.7      1.255      1.021         70        256: 100%|██████████| 605/605 [16:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.698      0.784      0.522      0.768      0.687      0.771      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     56/500      3.61G      1.134      1.703      1.255       1.02        145        256: 100%|██████████| 605/605 [10:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.697      0.784      0.522      0.767      0.687      0.772      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     57/500      4.32G      1.134      1.702      1.253       1.02         42        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.698      0.784      0.522      0.767      0.686      0.772      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     58/500      4.19G      1.133      1.699      1.253       1.02         79        256: 100%|██████████| 605/605 [06:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.698      0.784      0.522      0.767      0.687      0.771      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     59/500      3.99G      1.133      1.699      1.253      1.019         97        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.698      0.784      0.523      0.768      0.687      0.772      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     60/500      4.17G      1.132        1.7      1.253       1.02         81        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.698      0.784      0.523      0.768      0.686      0.772      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     61/500      3.83G      1.132      1.697      1.251      1.019        106        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.698      0.784      0.523       0.77      0.686      0.772      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     62/500      4.42G      1.133        1.7      1.251       1.02         83        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.698      0.784      0.523      0.769      0.686      0.772      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     63/500      4.14G      1.132      1.693       1.25      1.019        186        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.698      0.784      0.523       0.77      0.686      0.772       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     64/500      3.97G       1.13      1.691      1.249      1.018         81        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.699      0.784      0.523      0.769      0.687      0.772       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     65/500      4.24G       1.13      1.691      1.247      1.018        132        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.698      0.784      0.523      0.769      0.687      0.772       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     66/500      4.13G       1.13      1.694      1.248      1.018         76        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.697      0.784      0.523       0.77      0.686      0.772       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     67/500      3.94G       1.13      1.695      1.248      1.017        101        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.698      0.784      0.523      0.771      0.685      0.772       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     68/500      4.25G       1.13      1.692      1.249      1.017        122        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.698      0.784      0.523       0.77      0.686      0.772       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     69/500      4.45G      1.129      1.694      1.247      1.018         90        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.699      0.785      0.523      0.771      0.686      0.773      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     70/500      3.99G      1.127      1.689      1.247      1.017        104        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.699      0.785      0.523      0.771      0.686      0.773      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     71/500      3.97G      1.128      1.689      1.245      1.017         60        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.699      0.785      0.524      0.773      0.685      0.773      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     72/500      3.88G      1.127      1.687      1.244      1.017         35        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.699      0.785      0.524      0.773      0.686      0.773      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     73/500      4.28G      1.127      1.688      1.245      1.017        157        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775        0.7      0.785      0.524      0.773      0.686      0.773      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     74/500      4.02G      1.127      1.688      1.243      1.017         87        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.699      0.785      0.524      0.773      0.686      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     75/500      3.78G      1.125      1.687      1.243      1.016         90        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.785      0.524      0.772      0.687      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     76/500      4.16G      1.125      1.688      1.245      1.016         92        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.785      0.524      0.773      0.687      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     77/500      4.32G      1.126      1.687      1.244      1.015        162        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.785      0.524      0.773      0.687      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     78/500      3.78G      1.125      1.683       1.24      1.016         86        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777        0.7      0.785      0.524      0.773      0.687      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     79/500      4.02G      1.126      1.683      1.242      1.015         70        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.699      0.786      0.525      0.773      0.687      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     80/500      3.71G      1.125      1.685      1.239      1.016         84        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.786      0.525      0.773      0.688      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     81/500      3.75G      1.126      1.684      1.243      1.017         51        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.699      0.786      0.525      0.773      0.688      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     82/500      3.77G      1.125      1.683       1.24      1.015         90        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.699      0.786      0.525      0.773      0.688      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     83/500      4.15G      1.124      1.683       1.24      1.016         39        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.699      0.786      0.525      0.773      0.688      0.774      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     84/500      3.75G      1.124      1.682      1.239      1.016         46        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777        0.7      0.786      0.525      0.773      0.688      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     85/500      3.98G      1.125      1.682      1.239      1.015         51        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777        0.7      0.786      0.525      0.774      0.687      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     86/500      3.58G      1.123      1.681      1.238      1.014         39        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.699      0.786      0.525      0.773      0.688      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     87/500         4G      1.122      1.681      1.236      1.015         69        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.699      0.786      0.525      0.774      0.688      0.775      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     88/500      3.93G      1.122      1.678      1.235      1.015         80        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778        0.7      0.786      0.525      0.775      0.688      0.775      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     89/500      4.11G      1.122      1.677      1.236      1.014         67        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.699      0.787      0.525      0.775      0.688      0.775      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     90/500      3.84G      1.122      1.677      1.236      1.013        125        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.699      0.787      0.526      0.774      0.689      0.775      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     91/500      3.95G      1.123      1.677      1.237      1.015         48        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779        0.7      0.787      0.526      0.775      0.688      0.775      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     92/500      3.96G      1.121      1.677      1.234      1.015         98        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778        0.7      0.787      0.526      0.775      0.689      0.775      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     93/500      4.15G      1.119      1.676      1.235      1.013         92        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779        0.7      0.787      0.526      0.775      0.688      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     94/500      4.19G      1.119      1.677      1.233      1.013        116        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779        0.7      0.787      0.526      0.775      0.689      0.776      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     95/500      3.61G       1.12      1.676      1.235      1.014         39        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779        0.7      0.787      0.526      0.775      0.689      0.776      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     96/500      3.54G      1.119      1.675      1.233      1.013        107        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779        0.7      0.787      0.526      0.775      0.689      0.776      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     97/500       4.1G      1.121      1.677      1.233      1.013         96        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.787      0.526      0.775      0.689      0.776      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     98/500      3.81G       1.12      1.674      1.232      1.013         67        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.787      0.526      0.776      0.689      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "     99/500      4.33G      1.119      1.672      1.231      1.012         81        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.787      0.526      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    100/500      3.92G      1.118      1.672       1.23      1.012         50        256: 100%|██████████| 605/605 [05:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.787      0.526      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    101/500      4.13G      1.117      1.671       1.23      1.011         50        256: 100%|██████████| 605/605 [05:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.788      0.526      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    102/500      4.28G      1.118      1.673      1.228      1.011         93        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.788      0.526      0.776      0.689      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    103/500      3.87G      1.117       1.67      1.228      1.012         51        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.788      0.527      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    104/500      4.03G      1.116      1.669      1.229      1.011         52        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.788      0.527      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    105/500      3.68G      1.117      1.671      1.228      1.011        173        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.788      0.527      0.775      0.689      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    106/500      3.66G      1.117      1.668      1.227      1.011         79        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.788      0.527      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    107/500      3.87G      1.116      1.666      1.227      1.011         40        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.788      0.527      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    108/500       4.3G      1.117      1.667      1.226       1.01        114        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.788      0.527      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    109/500      3.91G      1.116      1.667      1.225      1.011        102        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.527      0.776       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    110/500      3.99G      1.115      1.668      1.225      1.011         71        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.788      0.527      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    111/500      3.94G      1.115      1.665      1.224      1.009         68        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.527      0.776       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    112/500      4.32G      1.115      1.667      1.224       1.01         84        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.527      0.776       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    113/500      3.91G      1.116      1.669      1.224       1.01        104        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.701      0.788      0.527      0.776       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    114/500      3.79G      1.115      1.664      1.223       1.01        103        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.701      0.788      0.527      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    115/500      4.08G      1.112      1.659      1.222      1.008         94        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.701      0.788      0.527      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    116/500      4.18G      1.115      1.663      1.222       1.01         52        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.701      0.788      0.527      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    117/500      4.15G      1.113      1.659      1.221      1.009        116        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.788      0.527      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    118/500      3.77G      1.114      1.664       1.22      1.009         64        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.789      0.527      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    119/500       3.8G      1.112      1.663      1.224      1.008         65        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.789      0.527      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    120/500      4.16G      1.114      1.662       1.22      1.009         56        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.789      0.528      0.776       0.69      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    121/500      3.92G      1.112       1.66      1.219      1.009         65        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.789      0.528      0.776       0.69      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    122/500      4.06G      1.113      1.661      1.219      1.009         51        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.789      0.528      0.776       0.69      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    123/500      3.93G      1.111       1.66      1.218      1.008         42        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.789      0.528      0.776       0.69      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    124/500      4.19G      1.112       1.66      1.218      1.009         71        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.704      0.789      0.528      0.775      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    125/500      3.97G      1.113       1.66      1.219       1.01         73        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.704      0.789      0.528      0.776      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    126/500       3.8G      1.112      1.663      1.217      1.008         62        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.704      0.789      0.528      0.775      0.692      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    127/500      3.83G       1.11      1.659      1.216      1.008         47        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.705      0.789      0.528      0.775      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    128/500      3.84G      1.111      1.657      1.214      1.008         94        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.704      0.789      0.528      0.775      0.691      0.778      0.467\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    129/500      4.08G       1.11      1.656      1.215      1.009        100        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.789      0.528      0.775      0.692      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    130/500      3.83G       1.11      1.654      1.213      1.007         77        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.789      0.528      0.776      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    131/500      3.64G      1.109      1.658      1.214      1.008         65        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.789      0.528      0.776      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    132/500      4.17G       1.11      1.656      1.213      1.008         57        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.704      0.788      0.528      0.776      0.692      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    133/500      3.91G      1.108      1.652      1.213      1.007         72        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.704      0.789      0.528      0.775      0.692      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    134/500      4.26G      1.109      1.654      1.212      1.006         97        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.705      0.789      0.528      0.776      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    135/500      3.98G      1.108      1.655      1.213      1.006         30        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.705      0.789      0.528      0.776      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    136/500      3.94G      1.108      1.656      1.213      1.006         23        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.705      0.789      0.528      0.776      0.692      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    137/500      3.83G      1.106      1.653      1.212      1.006         38        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.705      0.789      0.528      0.776      0.692      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    138/500       3.8G      1.108      1.652      1.211      1.007         49        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.704      0.789      0.528      0.775      0.692      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    139/500      4.37G      1.106      1.652      1.208      1.006         96        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.704      0.789      0.528      0.775      0.692      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    140/500      4.28G      1.105      1.648      1.207      1.006         41        256: 100%|██████████| 605/605 [05:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.705      0.789      0.528      0.775      0.693      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    141/500      4.14G      1.106      1.649      1.206      1.005         88        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.704      0.789      0.528      0.776      0.692      0.778      0.467\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    142/500      3.97G      1.105      1.647      1.207      1.006         39        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.704      0.789      0.528      0.776      0.692      0.778      0.467\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    143/500      3.82G      1.105      1.646      1.206      1.005        136        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.704      0.789      0.528      0.776      0.692      0.778      0.467\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    144/500      3.89G      1.106      1.647      1.205      1.006         50        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.777      0.691      0.778      0.467\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    145/500      3.94G      1.107       1.65      1.208      1.006        112        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.703      0.789      0.528      0.776      0.692      0.778      0.467\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    146/500      4.11G      1.105      1.646      1.205      1.005        116        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.789      0.528      0.777      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    147/500      4.26G      1.104      1.645      1.206      1.004         78        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.789      0.528      0.776      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    148/500      3.96G      1.106      1.644      1.205      1.006         28        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.777      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    149/500      4.22G      1.104      1.642      1.204      1.004         86        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.776      0.691      0.778      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    150/500         4G      1.104      1.644      1.203      1.005         66        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.789      0.528      0.776      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    151/500      3.77G      1.103      1.642      1.201      1.004         81        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.703      0.789      0.528      0.776      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    152/500      3.99G      1.103      1.644      1.201      1.005         54        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.775      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    153/500      4.45G      1.103      1.646      1.203      1.004         82        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.776      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    154/500      3.94G      1.103      1.642      1.202      1.004         47        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.776      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    155/500      3.93G      1.103      1.643        1.2      1.003         98        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.777       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    156/500      3.91G      1.103      1.643        1.2      1.003         41        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.777       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    157/500      4.08G      1.102      1.641        1.2      1.003         44        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.776      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    158/500      4.16G      1.102      1.641      1.198      1.003        117        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.777      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    159/500      3.49G      1.101      1.637      1.197      1.002        122        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.789      0.528      0.777       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    160/500       3.8G      1.101      1.642      1.198      1.003        101        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.781      0.702      0.789      0.528      0.777       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    161/500      4.11G      1.101      1.638      1.198      1.003         69        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.782      0.701      0.789      0.528      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    162/500      4.09G      1.101      1.639      1.198      1.002         31        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.781      0.702      0.788      0.528      0.777      0.689      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    163/500      3.81G      1.101      1.639      1.195      1.003        141        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.528      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    164/500      4.43G        1.1       1.64      1.195      1.002         21        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.788      0.528      0.776       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    165/500      3.68G      1.098      1.635      1.193      1.001        124        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.528      0.776      0.689      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    166/500      4.13G      1.099      1.635      1.192      1.002         66        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.528      0.775       0.69      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    167/500      4.08G      1.097      1.636      1.192      1.001        107        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.703      0.788      0.528      0.776       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    168/500      4.35G      1.099      1.635      1.191      1.001         71        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.703      0.788      0.528      0.776       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    169/500      3.84G      1.097      1.634       1.19      1.001         44        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.703      0.788      0.528      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    170/500      3.96G      1.098      1.635      1.189      1.001         88        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.703      0.788      0.528      0.775       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    171/500      3.63G      1.097      1.632      1.188      1.001        166        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.788      0.528      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    172/500      3.99G      1.097      1.634      1.188      1.002         42        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.788      0.528      0.777       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    173/500      3.81G      1.098      1.633      1.188      1.001        162        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.788      0.528      0.777       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    174/500      3.81G      1.097      1.633      1.188      1.001        137        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.528      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    175/500      3.97G      1.096      1.629      1.187      1.002         56        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.528      0.775      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    176/500      3.71G      1.097      1.629      1.187      1.001         57        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.703      0.788      0.528      0.775      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    177/500      4.18G      1.095       1.63      1.185      1.001         80        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.702      0.788      0.528      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    178/500      3.54G      1.095      1.632      1.185          1         92        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.701      0.788      0.528      0.776       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    179/500      3.92G      1.096       1.63      1.184          1         92        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.701      0.788      0.527      0.776       0.69      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    180/500      3.78G      1.097      1.628      1.185          1        108        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78      0.701      0.788      0.527      0.776       0.69      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    181/500      4.09G      1.094      1.627      1.185     0.9993         37        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.788      0.527      0.776      0.691      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    182/500      4.12G      1.093      1.627      1.181     0.9995         69        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.527      0.776      0.691      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    183/500      4.12G      1.092      1.627      1.181     0.9989         44        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.788      0.527      0.776      0.691      0.777      0.466\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    184/500      4.07G      1.093      1.626      1.182          1         95        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.703      0.788      0.527      0.775      0.692      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    185/500       3.6G      1.095      1.627      1.181     0.9995        152        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.787      0.527      0.775      0.691      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    186/500      3.81G      1.092      1.624      1.176     0.9986        112        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.788      0.528      0.774      0.691      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    187/500      3.88G       1.09      1.625      1.177     0.9983        171        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.703      0.788      0.527      0.774      0.692      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    188/500      4.09G      1.092      1.623      1.177     0.9993        144        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.703      0.787      0.527      0.773      0.692      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    189/500         4G      1.092       1.62      1.176     0.9976         89        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.703      0.787      0.527      0.773      0.691      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    190/500      3.92G      1.092      1.625      1.176     0.9988         68        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.703      0.787      0.527      0.773      0.692      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    191/500      3.81G      1.091       1.62      1.175     0.9985         68        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.704      0.787      0.527      0.774      0.691      0.777      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    192/500      3.94G       1.09      1.623      1.175     0.9988         98        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.704      0.787      0.527      0.773      0.691      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    193/500      3.61G      1.091      1.619      1.174     0.9977         54        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.787      0.527      0.774      0.691      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    194/500      3.72G      1.091      1.622      1.171     0.9969         44        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.702      0.787      0.527      0.774      0.691      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    195/500      4.11G       1.09      1.619      1.174     0.9971        108        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.702      0.787      0.527      0.773      0.691      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    196/500      3.84G       1.09      1.617      1.171     0.9961        101        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.703      0.787      0.527      0.772      0.692      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    197/500      3.96G       1.09      1.619      1.169     0.9969         64        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.704      0.787      0.527      0.773      0.692      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    198/500      3.94G      1.089      1.618      1.168     0.9968         78        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.703      0.787      0.527      0.772      0.692      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    199/500      3.96G      1.088      1.615      1.168     0.9964         62        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.702      0.787      0.527      0.773      0.691      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    200/500      3.86G      1.088      1.613      1.166     0.9959        113        256: 100%|██████████| 605/605 [05:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.703      0.787      0.526      0.774      0.691      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    201/500      4.38G      1.087      1.617      1.168     0.9947        158        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.526      0.774      0.691      0.776      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    202/500      3.92G      1.086      1.616      1.166     0.9955         74        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.786      0.526      0.773      0.691      0.775      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    203/500      3.95G      1.087      1.615      1.167     0.9952         82        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.702      0.786      0.526      0.774       0.69      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    204/500      3.57G      1.087      1.615      1.163     0.9945         63        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.526      0.773       0.69      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    205/500      3.76G      1.087      1.612      1.163     0.9955         53        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.702      0.786      0.526      0.773       0.69      0.775      0.465\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    206/500      4.17G      1.087      1.611      1.162     0.9959         59        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.526      0.774      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    207/500      3.81G      1.086      1.609      1.162     0.9946         62        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.526      0.774       0.69      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    208/500      4.38G      1.086      1.611      1.161     0.9953         48        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.526      0.775      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    209/500      3.57G      1.085      1.606       1.16      0.995         45        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.525      0.773      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    210/500       3.8G      1.085      1.609      1.159     0.9937         49        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.525      0.774      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    211/500       3.8G      1.086      1.609      1.158     0.9944         43        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.701      0.786      0.525      0.775      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    212/500       4.1G      1.085      1.609      1.157      0.994         73        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.525      0.775      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    213/500      3.92G      1.083      1.608      1.156     0.9939        151        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78        0.7      0.786      0.525      0.775      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    214/500      3.73G      1.084      1.604      1.155     0.9939         71        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78        0.7      0.786      0.525      0.775      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    215/500      3.94G      1.084      1.608      1.156     0.9934         93        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78        0.7      0.786      0.525      0.775      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    216/500      3.88G      1.083      1.607      1.154     0.9927         50        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.78        0.7      0.786      0.525      0.775      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    217/500      4.29G      1.081      1.601      1.153     0.9922        140        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.701      0.786      0.525      0.775      0.688      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    218/500       3.8G      1.083      1.606      1.153      0.993         83        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.786      0.525      0.775      0.689      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    219/500      4.04G      1.082        1.6      1.152     0.9924         43        256: 100%|██████████| 605/605 [04:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.701      0.786      0.525      0.774      0.689      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    220/500      4.38G       1.08      1.602       1.15     0.9921         94        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.786      0.525      0.775       0.69      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    221/500      4.09G      1.082      1.599      1.151     0.9934         55        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.786      0.525      0.775       0.69      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    222/500      4.01G      1.081      1.603       1.15      0.993        111        256: 100%|██████████| 605/605 [05:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.786      0.525      0.775       0.69      0.775      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    223/500      4.27G      1.081        1.6      1.151     0.9921        118        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.703      0.786      0.525      0.775      0.689      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    224/500      3.77G       1.08      1.602      1.148     0.9923         66        256: 100%|██████████| 605/605 [06:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.786      0.525      0.775      0.689      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    225/500       3.8G       1.08        1.6      1.146      0.993         86        256: 100%|██████████| 605/605 [07:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.701      0.785      0.525      0.775      0.689      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    226/500      3.68G      1.079      1.596      1.145     0.9924         47        256: 100%|██████████| 605/605 [07:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.785      0.525      0.774       0.69      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    227/500      3.94G       1.08      1.598      1.145     0.9925         70        256: 100%|██████████| 605/605 [07:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.702      0.785      0.524      0.774       0.69      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    228/500      4.08G      1.077      1.595      1.144     0.9911         80        256: 100%|██████████| 605/605 [07:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.785      0.524      0.774       0.69      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    229/500      3.59G      1.078      1.595      1.143     0.9912         45        256: 100%|██████████| 605/605 [08:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.702      0.785      0.524      0.773       0.69      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    230/500      3.82G      1.079      1.594      1.142     0.9915         70        256: 100%|██████████| 605/605 [07:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.703      0.785      0.524      0.773      0.691      0.774      0.464\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    231/500      4.09G      1.078      1.593      1.141     0.9912        112        256: 100%|██████████| 605/605 [07:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.703      0.785      0.524      0.772      0.691      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    232/500      4.31G      1.077      1.594      1.141     0.9912         61        256: 100%|██████████| 605/605 [07:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.703      0.785      0.524      0.772      0.691      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    233/500      4.35G      1.077      1.594       1.14       0.99         91        256: 100%|██████████| 605/605 [07:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.704      0.785      0.524      0.772      0.691      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    234/500      4.14G      1.076      1.594      1.138     0.9905         76        256: 100%|██████████| 605/605 [09:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.703      0.785      0.524      0.774       0.69      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    235/500      4.42G      1.076      1.591       1.14     0.9892        141        256: 100%|██████████| 605/605 [09:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.703      0.785      0.524      0.773       0.69      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    236/500      3.95G      1.075       1.59      1.138     0.9897         47        256: 100%|██████████| 605/605 [10:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.704      0.785      0.524      0.772       0.69      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    237/500      4.02G      1.076      1.591       1.14     0.9893        132        256: 100%|██████████| 605/605 [09:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.703      0.785      0.524      0.773       0.69      0.774      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    238/500      3.61G      1.075      1.591      1.136     0.9894        100        256: 100%|██████████| 605/605 [09:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.702      0.785      0.524      0.773       0.69      0.773      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    239/500      4.23G      1.076      1.586      1.133     0.9898         66        256: 100%|██████████| 605/605 [08:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.703      0.785      0.524      0.773       0.69      0.773      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    240/500      3.78G      1.074      1.587      1.134     0.9891        147        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.702      0.785      0.523      0.773      0.689      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    241/500      3.99G      1.075      1.587      1.134     0.9899         27        256: 100%|██████████| 605/605 [08:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.702      0.784      0.523      0.774      0.689      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    242/500      3.75G      1.073      1.587      1.131     0.9904         57        256: 100%|██████████| 605/605 [17:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.702      0.784      0.523      0.774      0.689      0.773      0.463\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    243/500       3.7G      1.074      1.589       1.13     0.9885         69        256: 100%|██████████| 605/605 [15:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.784      0.523      0.774      0.689      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    244/500      4.08G      1.072      1.582      1.128     0.9877         44        256: 100%|██████████| 605/605 [08:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.784      0.523      0.774      0.689      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    245/500      3.91G      1.073      1.582       1.13     0.9888         47        256: 100%|██████████| 605/605 [08:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.784      0.523      0.775      0.689      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    246/500      4.24G      1.073      1.584      1.128     0.9886         72        256: 100%|██████████| 605/605 [08:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.702      0.784      0.523      0.775      0.689      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    247/500      4.23G       1.07       1.58      1.127     0.9876         20        256: 100%|██████████| 605/605 [07:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.784      0.523      0.775      0.688      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    248/500       3.8G       1.07      1.579      1.125     0.9875        103        256: 100%|██████████| 605/605 [08:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.701      0.784      0.523      0.775      0.689      0.773      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    249/500      3.95G      1.071      1.582      1.124     0.9875        117        256: 100%|██████████| 605/605 [08:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779        0.7      0.784      0.522      0.776      0.688      0.772      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    250/500      3.95G      1.071      1.579      1.124     0.9879         74        256: 100%|██████████| 605/605 [07:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778        0.7      0.784      0.522      0.775      0.688      0.772      0.462\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    251/500      4.26G      1.071       1.58      1.122     0.9872         58        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778        0.7      0.783      0.522      0.776      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    252/500      3.59G       1.07      1.577      1.124     0.9864         68        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778        0.7      0.783      0.522      0.776      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    253/500         4G      1.068      1.575      1.121     0.9867        135        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.699      0.783      0.522      0.777      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    254/500      4.18G      1.068      1.573      1.119     0.9864        105        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778        0.7      0.783      0.522      0.775      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    255/500      3.98G      1.069      1.575      1.119     0.9869         80        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.699      0.783      0.522      0.775      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    256/500      3.71G      1.067      1.577      1.118     0.9862         40        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.699      0.783      0.522      0.775      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    257/500      4.13G      1.067      1.571       1.12     0.9868         63        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.699      0.783      0.522      0.775      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    258/500      3.83G      1.069      1.575      1.118     0.9869         79        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.699      0.783      0.522      0.775      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    259/500      3.76G      1.067      1.572      1.118     0.9862         95        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777        0.7      0.782      0.521      0.775      0.687      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    260/500      3.59G      1.066       1.57      1.116     0.9853         82        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777        0.7      0.782      0.521      0.774      0.688      0.771      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    261/500       3.9G      1.064      1.568      1.112     0.9854         38        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.782      0.521      0.773      0.689      0.772      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    262/500      3.97G      1.065      1.568      1.114     0.9852         71        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777        0.7      0.782      0.521      0.774      0.688      0.771      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    263/500      3.89G      1.065      1.571      1.112     0.9861         70        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.782      0.521      0.774      0.688      0.771      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    264/500      3.88G      1.064      1.568      1.111     0.9841        112        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.699      0.782      0.521      0.774      0.688      0.771      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    265/500      3.95G      1.065      1.567      1.113     0.9845         17        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.782      0.521      0.773      0.688      0.771      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    266/500      3.62G      1.063      1.567       1.11     0.9848         84        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.782       0.52      0.773      0.688      0.771      0.461\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    267/500      3.75G      1.063      1.567      1.109     0.9847         36        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.699      0.782       0.52      0.773      0.688      0.771       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    268/500      3.77G      1.064      1.565      1.107      0.985         74        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.699      0.782       0.52      0.772      0.688      0.771       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    269/500      4.22G      1.061      1.563      1.106     0.9835         94        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.699      0.782       0.52      0.772      0.688      0.771       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    270/500      4.09G      1.061      1.561      1.106     0.9826        117        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.699      0.782       0.52      0.772      0.689      0.771       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    271/500      3.56G      1.061       1.56      1.106     0.9832         94        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.699      0.782       0.52      0.772      0.688       0.77       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    272/500      4.32G      1.061       1.56      1.104     0.9835         73        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.699      0.781       0.52      0.772      0.689      0.771       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    273/500      4.23G       1.06       1.56      1.101     0.9823         48        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.699      0.781       0.52      0.772      0.689      0.771       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    274/500      4.13G      1.061       1.56      1.103      0.984         17        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.699      0.781       0.52      0.772      0.688       0.77       0.46\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    275/500      3.88G      1.061      1.558      1.101     0.9834         79        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.699      0.781       0.52      0.772      0.688       0.77      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    276/500      4.11G       1.06      1.556      1.102     0.9829         77        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776        0.7      0.781       0.52      0.772      0.688       0.77      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    277/500       3.8G      1.058      1.555        1.1     0.9815         53        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.699      0.781       0.52      0.773      0.688       0.77      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    278/500      4.08G      1.059      1.557      1.098     0.9814         79        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.698      0.781      0.519      0.773      0.687       0.77      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    279/500      3.79G      1.058      1.556      1.098     0.9821         51        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.698      0.781      0.519      0.773      0.687       0.77      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    280/500      4.22G      1.057      1.553      1.095     0.9822         96        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.697      0.781      0.519      0.774      0.687       0.77      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    281/500      4.01G      1.056      1.554      1.093     0.9813         41        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.697      0.781      0.519      0.774      0.686       0.77      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    282/500      4.38G      1.057      1.554      1.094      0.982         86        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.697      0.781      0.519      0.774      0.686       0.77      0.459\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    283/500      3.88G      1.056      1.553       1.09      0.981         87        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.697       0.78      0.519      0.773      0.686       0.77      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    284/500      3.59G      1.056      1.552      1.092     0.9814         91        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.698       0.78      0.519      0.772      0.686      0.769      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    285/500      3.92G      1.055      1.551      1.093     0.9808         66        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.698       0.78      0.519      0.772      0.687      0.769      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    286/500       3.9G      1.053      1.549      1.089     0.9802        102        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.698       0.78      0.519      0.772      0.687      0.769      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    287/500      4.16G      1.054       1.55      1.087     0.9796         85        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.697       0.78      0.519      0.771      0.687      0.769      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    288/500      3.95G      1.055       1.55      1.089     0.9805        101        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.697       0.78      0.519      0.772      0.686      0.769      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    289/500      3.64G      1.054      1.551      1.087     0.9808        195        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.697       0.78      0.518      0.772      0.686      0.769      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    290/500      3.93G      1.054      1.547      1.087     0.9807         22        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.697      0.779      0.518      0.772      0.686      0.769      0.458\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    291/500      4.46G      1.051      1.543      1.082     0.9793         68        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.697      0.779      0.518      0.772      0.686      0.769      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    292/500      4.26G      1.051      1.544      1.083     0.9785        116        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.696      0.779      0.518      0.772      0.686      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    293/500      4.01G      1.051      1.544      1.083      0.978        135        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.697      0.779      0.518      0.772      0.685      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    294/500      3.78G      1.049      1.541       1.08     0.9776         62        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.696      0.779      0.518      0.772      0.685      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    295/500      4.27G      1.051       1.54      1.079      0.979        152        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.697      0.779      0.518      0.773      0.685      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    296/500      3.92G       1.05      1.541      1.079     0.9791         61        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.696      0.779      0.518      0.773      0.685      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    297/500      3.81G       1.05       1.54      1.079     0.9776         90        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.697      0.779      0.518      0.774      0.684      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    298/500      4.02G      1.049      1.539      1.075     0.9778         41        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.696      0.779      0.518      0.774      0.685      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    299/500       4.1G      1.048      1.538      1.077     0.9773         52        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.696      0.779      0.517      0.774      0.684      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    300/500      4.23G      1.048      1.537      1.075     0.9778         48        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.695      0.779      0.517      0.774      0.684      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    301/500      3.79G      1.047      1.538      1.075     0.9777         73        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.695      0.778      0.517      0.773      0.684      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    302/500      4.25G      1.046      1.535      1.073     0.9769        123        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.695      0.778      0.517      0.774      0.684      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    303/500      4.08G      1.047      1.535      1.072     0.9773         50        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.694      0.778      0.517      0.774      0.684      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    304/500      4.08G      1.047      1.532      1.073     0.9762         68        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.695      0.778      0.517      0.775      0.683      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    305/500       4.1G      1.044      1.531      1.068     0.9754        117        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.778      0.695      0.778      0.517      0.775      0.683      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    306/500      3.92G      1.044      1.532      1.069     0.9753         86        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.778      0.517      0.774      0.684      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    307/500      4.38G      1.044      1.531      1.068     0.9759         84        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.778      0.516      0.774      0.684      0.768      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    308/500      3.63G      1.044      1.531      1.066      0.975         95        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.695      0.778      0.516      0.773      0.684      0.767      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    309/500      3.91G      1.044      1.529      1.067     0.9751         98        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.694      0.778      0.516      0.773      0.684      0.767      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    310/500      3.93G      1.042      1.526      1.063      0.975        168        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.778      0.516      0.773      0.684      0.767      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    311/500      3.89G      1.042      1.527      1.061     0.9751         72        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.696      0.778      0.516      0.774      0.683      0.767      0.457\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    312/500      3.83G      1.042      1.526      1.061     0.9748        120        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.777      0.516      0.772      0.684      0.767      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    313/500      3.74G      1.041      1.524      1.061     0.9751         45        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.695      0.778      0.516      0.773      0.684      0.767      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    314/500      3.83G       1.04      1.522      1.059     0.9748         58        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.695      0.777      0.516      0.772      0.684      0.767      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    315/500      3.92G      1.041      1.523       1.06     0.9741         71        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.694      0.777      0.516      0.771      0.684      0.767      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    316/500      3.93G      1.039       1.52      1.059     0.9743         46        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.694      0.777      0.516      0.772      0.684      0.767      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    317/500      4.36G       1.04      1.521      1.057     0.9734         53        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.696      0.777      0.516      0.772      0.684      0.767      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    318/500       3.5G      1.038      1.519      1.055      0.973         83        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.696      0.777      0.516      0.773      0.683      0.766      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    319/500      3.57G      1.038      1.518      1.054     0.9734         48        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.776      0.515      0.771      0.685      0.766      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    320/500      3.75G      1.038      1.519      1.053     0.9734         55        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.696      0.776      0.515      0.771      0.685      0.766      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    321/500      4.16G      1.038      1.515      1.051     0.9728         90        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.776      0.515      0.771      0.684      0.766      0.456\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    322/500      3.86G      1.037      1.518      1.051      0.973         69        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.777      0.515      0.771      0.684      0.766      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    323/500      3.88G      1.036      1.516       1.05     0.9731         73        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.776      0.515      0.771      0.685      0.766      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    324/500      4.17G      1.034      1.513      1.048     0.9719        100        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.776      0.515       0.77      0.685      0.766      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    325/500       3.9G      1.035       1.51      1.046     0.9717         80        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.776      0.515      0.771      0.685      0.766      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    326/500      4.25G      1.035      1.511      1.046     0.9713         60        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.777      0.694      0.776      0.515      0.771      0.684      0.766      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    327/500      3.77G      1.034       1.51      1.046     0.9714         79        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.776      0.515      0.772      0.684      0.766      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    328/500       3.7G      1.032      1.508      1.044     0.9703         97        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.776      0.514      0.771      0.684      0.766      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    329/500      3.61G      1.034      1.508       1.04     0.9717        107        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.695      0.776      0.514      0.772      0.683      0.765      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    330/500      3.98G      1.034       1.51       1.04      0.971         69        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.694      0.776      0.514      0.772      0.683      0.765      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    331/500      3.56G      1.032      1.506       1.04     0.9708         63        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.775      0.514      0.772      0.684      0.765      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    332/500      4.05G      1.033      1.505       1.04     0.9711         89        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.775      0.514      0.772      0.683      0.765      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    333/500         4G      1.031      1.504      1.037     0.9691        114        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.775      0.514      0.772      0.683      0.765      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    334/500      3.92G       1.03      1.502      1.036     0.9697         58        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.776      0.695      0.775      0.514      0.772      0.683      0.765      0.455\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    335/500      4.36G       1.03      1.505      1.037       0.97         64        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.775      0.696      0.775      0.514      0.772      0.683      0.765      0.454\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    336/500      3.94G      1.029      1.499      1.035     0.9692        152        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.775      0.513      0.771      0.684      0.764      0.454\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    337/500      3.92G      1.028        1.5      1.032     0.9691         62        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.696      0.775      0.513       0.77      0.684      0.764      0.454\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    338/500      3.72G      1.027        1.5      1.031     0.9683         75        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.695      0.775      0.513      0.771      0.683      0.764      0.454\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    339/500      4.34G      1.027      1.497       1.03      0.968         77        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.695      0.774      0.513      0.772      0.683      0.764      0.454\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    340/500      3.83G      1.027      1.498      1.031     0.9681        181        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.696      0.774      0.513       0.77      0.684      0.764      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    341/500      3.74G      1.026      1.498      1.028     0.9677        103        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.695      0.774      0.513       0.77      0.683      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    342/500      4.25G      1.026      1.493      1.027     0.9672         43        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.774      0.513      0.771      0.682      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    343/500      3.88G      1.024      1.493      1.024     0.9669         49        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.696      0.774      0.512       0.77      0.683      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    344/500      3.71G      1.024      1.491      1.024     0.9668         53        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.696      0.774      0.512      0.769      0.683      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    345/500      4.24G      1.025      1.492      1.023     0.9672        100        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.773      0.512      0.769      0.683      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    346/500       4.1G      1.024      1.492      1.021     0.9672         88        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.696      0.773      0.512      0.771      0.682      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    347/500      4.59G      1.022      1.492       1.02      0.965        132        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.774      0.694      0.773      0.512      0.769      0.683      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    348/500      3.48G      1.022       1.49      1.019     0.9656        115        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.773      0.512       0.77      0.682      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    349/500      4.48G      1.022      1.489       1.02      0.966        123        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.773      0.512      0.771      0.682      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    350/500      3.72G       1.02      1.486      1.015     0.9654         68        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.773      0.511      0.771      0.682      0.763      0.453\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    351/500       3.9G      1.021      1.486      1.017     0.9654         83        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.694      0.773      0.511      0.772      0.681      0.762      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    352/500      3.81G      1.021      1.484      1.016     0.9651        131        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.694      0.773      0.511      0.771      0.682      0.762      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    353/500         4G      1.018      1.479      1.013     0.9643         76        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.694      0.773      0.511      0.771      0.681      0.762      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    354/500      3.76G      1.019      1.484      1.013     0.9651        134        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.773      0.511      0.771      0.681      0.762      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    355/500      3.93G      1.017      1.479      1.009      0.964         45        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.772      0.511      0.772      0.681      0.762      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    356/500      3.72G      1.017      1.477      1.009     0.9639         37        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.772       0.51      0.771      0.682      0.762      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    357/500      3.97G      1.017      1.476      1.007     0.9635         42        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.772       0.51       0.77      0.682      0.761      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    358/500      3.77G      1.017      1.476      1.006     0.9626         80        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.772       0.51       0.77      0.683      0.762      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    359/500      3.91G      1.016      1.477      1.005     0.9629         81        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.772       0.51      0.769      0.683      0.761      0.452\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    360/500      3.52G      1.015      1.472      1.004     0.9627         45        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.695      0.772       0.51      0.769      0.683      0.761      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    361/500      3.89G      1.015      1.474      1.003     0.9626         29        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.696      0.772       0.51      0.768      0.684      0.761      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    362/500      3.89G      1.013      1.471          1     0.9624         86        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.696      0.771       0.51      0.768      0.684      0.761      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    363/500      3.89G      1.013       1.47     0.9992     0.9629         68        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.695      0.771       0.51      0.769      0.684      0.761      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    364/500      4.15G      1.013       1.47     0.9991     0.9618         92        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.696      0.771      0.509      0.769      0.683      0.761      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    365/500      4.29G      1.012       1.47     0.9972     0.9613         65        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.696      0.771      0.509      0.769      0.684      0.761      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    366/500      3.88G      1.011      1.469      0.994     0.9609         44        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.696      0.771      0.509      0.768      0.684       0.76      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    367/500      3.85G       1.01      1.467     0.9929     0.9601         86        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.696      0.771      0.509      0.767      0.684       0.76      0.451\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    368/500      4.03G       1.01      1.467     0.9907     0.9606         73        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.696      0.771      0.509      0.766      0.684       0.76       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    369/500      4.31G       1.01      1.464       0.99     0.9603         68        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.697       0.77      0.509      0.767      0.684       0.76       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    370/500      3.79G      1.008      1.463     0.9895     0.9596        147        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.696       0.77      0.509      0.766      0.685       0.76       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    371/500      3.84G      1.008      1.463     0.9889     0.9593        164        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.696       0.77      0.508      0.766      0.685       0.76       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    372/500      3.61G      1.007      1.461     0.9856     0.9591         65        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.696       0.77      0.508      0.766      0.685       0.76       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    373/500      3.92G      1.006      1.459     0.9844     0.9581        135        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.695       0.77      0.508      0.766      0.685       0.76       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    374/500      4.16G      1.007       1.46     0.9842     0.9589         77        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.695       0.77      0.508      0.767      0.683       0.76       0.45\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    375/500      4.04G      1.005      1.456     0.9814     0.9583         32        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.696       0.77      0.508      0.766      0.684      0.759      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    376/500      4.11G      1.003      1.452     0.9807     0.9573         55        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.695       0.77      0.508      0.767      0.683       0.76      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    377/500      3.92G      1.003      1.454     0.9801     0.9574         88        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.694      0.769      0.507      0.768      0.682      0.759      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    378/500      3.93G      1.005      1.455      0.979     0.9582         45        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.694      0.769      0.507      0.768      0.683      0.759      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    379/500      4.11G      1.002      1.451     0.9757     0.9566         45        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.694      0.769      0.507      0.768      0.682      0.759      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    380/500      3.93G      1.001       1.45     0.9758     0.9567        141        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.773      0.693      0.769      0.507      0.769      0.682      0.759      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    381/500      3.55G      1.001      1.447     0.9727     0.9567         99        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.694      0.769      0.507      0.769      0.682      0.759      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    382/500      3.77G      1.001      1.449     0.9711     0.9559         45        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.694      0.769      0.507      0.768      0.681      0.759      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    383/500      4.07G     0.9984      1.444     0.9687     0.9545         69        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.694      0.768      0.507      0.769       0.68      0.759      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    384/500      3.94G     0.9988      1.444      0.966     0.9547         55        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.694      0.768      0.506      0.768      0.681      0.758      0.449\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    385/500       3.9G      0.998       1.44      0.966     0.9549         83        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.693      0.768      0.506      0.768      0.681      0.758      0.448\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    386/500      4.22G     0.9986      1.445     0.9663     0.9553         68        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.693      0.768      0.506      0.768       0.68      0.758      0.448\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    387/500      3.69G     0.9969      1.441     0.9645     0.9542        121        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.694      0.768      0.506      0.766      0.682      0.758      0.448\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    388/500      4.08G      0.997       1.44     0.9632      0.955         44        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.694      0.768      0.506      0.765      0.682      0.758      0.448\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    389/500      3.64G      0.997      1.439      0.962     0.9545        127        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.694      0.768      0.506      0.767      0.681      0.758      0.448\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    390/500      3.65G     0.9942      1.433     0.9593     0.9535         65        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.694      0.768      0.506      0.766      0.681      0.758      0.448\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    391/500         4G     0.9932      1.433     0.9582     0.9532         71        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.693      0.767      0.505      0.766      0.681      0.758      0.448\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    392/500      3.57G     0.9929      1.434     0.9559     0.9521         61        256: 100%|██████████| 605/605 [08:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.767      0.505      0.768      0.681      0.757      0.448\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    393/500      4.06G     0.9927      1.434     0.9544     0.9521         71        256: 100%|██████████| 605/605 [07:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.691      0.767      0.505      0.767      0.681      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    394/500      4.12G     0.9919       1.43     0.9526     0.9527         38        256: 100%|██████████| 605/605 [07:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.767      0.505      0.767      0.681      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    395/500      4.09G     0.9902      1.428     0.9512     0.9517         83        256: 100%|██████████| 605/605 [08:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.767      0.505      0.767      0.682      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    396/500      4.01G     0.9894      1.427     0.9509     0.9505         83        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.693      0.767      0.505      0.767      0.681      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    397/500      4.07G     0.9885      1.426      0.949      0.951         56        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.693      0.767      0.504      0.765      0.682      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    398/500      3.94G     0.9876      1.425     0.9472     0.9502        105        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.694      0.767      0.504      0.765      0.682      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    399/500      3.82G     0.9871      1.422     0.9459     0.9499        145        256: 100%|██████████| 605/605 [06:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.693      0.767      0.504      0.766      0.682      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    400/500      4.11G     0.9859       1.42     0.9429     0.9501        112        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.693      0.766      0.504      0.765      0.682      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    401/500      4.12G     0.9873       1.42     0.9423     0.9496        137        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.766      0.504      0.765      0.682      0.757      0.447\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    402/500      3.73G     0.9843      1.417     0.9394      0.949         73        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.692      0.766      0.504      0.767      0.681      0.756      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    403/500      4.05G     0.9846      1.417     0.9408       0.95         75        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.766      0.503      0.768       0.68      0.756      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    404/500      3.95G     0.9845      1.415      0.939     0.9491         87        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.691      0.766      0.503      0.769      0.679      0.756      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    405/500      4.21G     0.9821      1.412     0.9335     0.9484         65        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.766      0.503      0.767      0.681      0.756      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    406/500      3.76G     0.9834      1.411     0.9337     0.9482         68        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.691      0.765      0.503      0.767       0.68      0.756      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    407/500      3.93G     0.9813      1.411     0.9317     0.9477        101        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.765      0.503      0.768       0.68      0.756      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    408/500      3.72G     0.9811      1.408     0.9314     0.9478        101        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.772      0.691      0.765      0.502      0.767      0.681      0.756      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    409/500      4.01G     0.9785      1.406     0.9315     0.9465         35        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.691      0.765      0.502      0.767       0.68      0.755      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    410/500      4.31G     0.9797      1.406     0.9286     0.9467         70        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.692      0.765      0.502      0.766      0.681      0.755      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    411/500      4.03G     0.9784      1.404     0.9256     0.9465         56        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.692      0.765      0.502      0.766      0.681      0.755      0.446\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    412/500      3.74G     0.9769      1.405     0.9236      0.946        108        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.693      0.764      0.502      0.766      0.681      0.755      0.445\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    413/500       3.6G     0.9765      1.401     0.9223     0.9457         86        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.693      0.764      0.502      0.765       0.68      0.754      0.445\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    414/500      3.76G     0.9751      1.399     0.9212     0.9452         83        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.693      0.764      0.502      0.764      0.681      0.754      0.445\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    415/500      3.98G     0.9744      1.398      0.919     0.9447        130        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.692      0.764      0.502      0.764      0.681      0.754      0.445\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    416/500      4.05G     0.9728      1.395      0.916     0.9443         36        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.692      0.764      0.502      0.765       0.68      0.754      0.445\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    417/500      3.58G     0.9731      1.395     0.9149      0.944         80        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.691      0.763      0.501      0.765       0.68      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    418/500      3.89G     0.9724      1.395     0.9134      0.944        118        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.691      0.763      0.501      0.765       0.68      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    419/500      3.74G     0.9722      1.392     0.9134     0.9439         68        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.692      0.763      0.501      0.766      0.679      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    420/500      4.09G       0.97      1.391     0.9092     0.9431         84        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.691      0.763      0.501      0.767      0.678      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    421/500      4.05G     0.9687      1.386     0.9073     0.9428        108        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771       0.69      0.763      0.501      0.767      0.678      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    422/500      3.96G     0.9684      1.388     0.9071     0.9426         35        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771       0.69      0.763        0.5      0.767      0.678      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    423/500      3.74G     0.9677      1.385     0.9053     0.9418         46        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771       0.69      0.763        0.5      0.767      0.678      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    424/500      4.28G     0.9667      1.383     0.9027      0.942         29        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771       0.69      0.763        0.5      0.768      0.678      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    425/500      4.25G     0.9646      1.381     0.8989     0.9406         67        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77       0.69      0.762        0.5      0.768      0.678      0.753      0.444\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    426/500      4.06G     0.9639      1.381     0.8974      0.941         87        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77       0.69      0.762        0.5      0.767      0.679      0.752      0.443\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    427/500       3.7G     0.9637      1.379     0.8938     0.9406        118        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77       0.69      0.762        0.5      0.767      0.679      0.752      0.443\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    428/500      3.76G      0.962      1.375     0.8932     0.9393         79        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77       0.69      0.761      0.499      0.767      0.678      0.752      0.443\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    429/500      4.03G     0.9616      1.375      0.892     0.9393         91        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.689      0.761      0.499      0.767      0.678      0.752      0.443\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    430/500      3.63G     0.9611      1.372     0.8917     0.9388         49        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.689      0.761      0.499      0.767      0.677      0.751      0.443\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    431/500      3.92G     0.9597       1.37      0.888     0.9387         68        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.689      0.761      0.499      0.766      0.677      0.751      0.442\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    432/500      4.07G     0.9588      1.368     0.8875     0.9384         63        256: 100%|██████████| 605/605 [07:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.689      0.761      0.498      0.766      0.677      0.751      0.442\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    433/500      4.07G     0.9579      1.365     0.8839      0.938        179        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.689       0.76      0.498      0.766      0.678      0.751      0.442\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    434/500      4.07G     0.9557      1.364     0.8816     0.9371         66        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768       0.69       0.76      0.498      0.766      0.677       0.75      0.442\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    435/500      3.57G     0.9555       1.36     0.8791     0.9363         62        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.689       0.76      0.498      0.767      0.677       0.75      0.442\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    436/500      3.83G     0.9545      1.361      0.879     0.9362         45        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.689       0.76      0.497      0.767      0.676       0.75      0.442\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    437/500      4.16G     0.9528       1.36      0.877     0.9363         83        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.688       0.76      0.497      0.766      0.676       0.75      0.441\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    438/500      4.32G      0.953      1.358     0.8751     0.9355         31        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.688      0.759      0.497      0.767      0.676       0.75      0.441\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    439/500      3.86G     0.9509      1.355     0.8728     0.9348         52        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.767      0.689      0.759      0.497      0.765      0.677      0.749      0.441\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    440/500      3.93G     0.9507      1.351     0.8702     0.9343         69        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.767      0.689      0.759      0.496      0.766      0.677      0.749      0.441\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    441/500       3.9G     0.9492      1.351     0.8689     0.9341         61        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.767      0.689      0.759      0.496      0.766      0.676      0.749       0.44\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    442/500      3.89G     0.9478       1.35     0.8661     0.9336        194        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.688      0.758      0.496      0.767      0.676      0.749       0.44\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    443/500      4.14G      0.947      1.347     0.8648     0.9331         35        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.688      0.758      0.496      0.767      0.675      0.748       0.44\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    444/500      3.68G     0.9458      1.346     0.8616     0.9327         70        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.688      0.758      0.495      0.767      0.675      0.748       0.44\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    445/500      3.92G     0.9457      1.345     0.8621     0.9329        140        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.688      0.758      0.495      0.768      0.675      0.748       0.44\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    446/500      3.83G     0.9431       1.34     0.8561     0.9312        100        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.688      0.757      0.495      0.767      0.675      0.748       0.44\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    447/500       3.7G     0.9412      1.337     0.8544     0.9302         65        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.688      0.757      0.495      0.767      0.675      0.748      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    448/500       4.2G     0.9404      1.337      0.853       0.93        102        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.688      0.757      0.495      0.768      0.675      0.748      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    449/500      3.72G     0.9391      1.334     0.8504     0.9296         92        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.688      0.757      0.494      0.767      0.675      0.748      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    450/500      4.26G     0.9389       1.33     0.8485      0.929         57        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.688      0.757      0.494      0.768      0.675      0.748      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    451/500      3.65G     0.9375       1.33     0.8464     0.9284         32        256: 100%|██████████| 605/605 [07:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.688      0.756      0.494      0.767      0.675      0.748      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    452/500      4.05G     0.9365      1.329     0.8445     0.9289        114        256: 100%|██████████| 605/605 [06:2\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.687      0.756      0.494      0.766      0.677      0.747      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    453/500      4.26G      0.935      1.324     0.8418     0.9275         61        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.687      0.756      0.494      0.766      0.676      0.747      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    454/500      4.04G     0.9333      1.322     0.8401     0.9274         51        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.687      0.756      0.494      0.766      0.675      0.747      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    455/500      4.23G     0.9333      1.322     0.8383     0.9266         97        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.687      0.756      0.493      0.765      0.676      0.747      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    456/500      4.26G     0.9309      1.319     0.8362     0.9262         67        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.687      0.756      0.493      0.766      0.676      0.747      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    457/500      3.98G     0.9296      1.318     0.8336     0.9264         34        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.687      0.755      0.493      0.766      0.675      0.746      0.439\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    458/500      3.62G     0.9293      1.314     0.8306     0.9259         56        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.686      0.755      0.493      0.767      0.675      0.746      0.438\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    459/500      4.14G     0.9293      1.313     0.8293     0.9261         62        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.686      0.755      0.492      0.767      0.675      0.746      0.438\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    460/500      4.14G     0.9277       1.31     0.8276     0.9251        108        256: 100%|██████████| 605/605 [06:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.687      0.755      0.492      0.768      0.674      0.746      0.438\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    461/500      3.74G     0.9261       1.31     0.8247     0.9243        151        256: 100%|██████████| 605/605 [07:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.687      0.754      0.492      0.767      0.674      0.745      0.438\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    462/500      3.99G     0.9258      1.306     0.8237      0.924         43        256: 100%|██████████| 605/605 [06:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.686      0.754      0.492      0.767      0.674      0.745      0.438\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    463/500      3.91G     0.9229      1.304     0.8209     0.9238        126        256: 100%|██████████| 605/605 [06:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.685      0.754      0.492      0.767      0.674      0.745      0.437\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    464/500         4G     0.9207        1.3     0.8152     0.9221         30        256: 100%|██████████| 605/605 [06:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.685      0.754      0.491      0.767      0.675      0.745      0.437\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    465/500      3.85G     0.9214      1.302     0.8163     0.9226         89        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.686      0.754      0.491      0.766      0.674      0.745      0.437\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    466/500      3.73G     0.9179      1.296     0.8109      0.922         50        256: 100%|██████████| 605/605 [06:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.685      0.753      0.491      0.766      0.674      0.744      0.437\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    467/500      4.09G     0.9183      1.294     0.8096     0.9209         62        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.686      0.753      0.491      0.768      0.673      0.744      0.436\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    468/500       3.8G     0.9162      1.295     0.8076     0.9208         85        256: 100%|██████████| 605/605 [06:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.685      0.753       0.49      0.768      0.673      0.744      0.436\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    469/500      3.67G     0.9146       1.29     0.8043     0.9199        105        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.684      0.753       0.49      0.767      0.673      0.743      0.436\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    470/500      3.89G     0.9146      1.289     0.8045       0.92         75        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.684      0.752       0.49      0.767      0.673      0.743      0.436\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    471/500      4.25G      0.912      1.284     0.8005     0.9189         78        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.771      0.684      0.752       0.49      0.766      0.673      0.743      0.435\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    472/500      3.86G     0.9116      1.283     0.7971     0.9187         71        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177       0.77      0.685      0.752      0.489      0.766      0.673      0.743      0.435\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    473/500      4.11G     0.9088      1.278     0.7946     0.9174         62        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.685      0.752      0.489      0.766      0.673      0.742      0.435\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    474/500      3.97G     0.9083      1.277     0.7919     0.9178         73        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.769      0.684      0.751      0.489      0.766      0.673      0.742      0.435\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    475/500      4.14G     0.9067      1.276     0.7896     0.9173         45        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.768      0.685      0.751      0.488      0.765      0.674      0.742      0.434\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    476/500      3.74G     0.9052      1.268      0.786     0.9172         89        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.767      0.685       0.75      0.488      0.766      0.673      0.741      0.434\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    477/500      3.78G     0.9055       1.27     0.7853     0.9169         58        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.767      0.685       0.75      0.488      0.764      0.674      0.741      0.434\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    478/500      3.85G     0.9039      1.268     0.7844     0.9161         85        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.767      0.685       0.75      0.487      0.764      0.674      0.741      0.434\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    479/500       3.9G     0.9017      1.264     0.7792     0.9153         95        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.766      0.686       0.75      0.487      0.764      0.674       0.74      0.433\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    480/500      3.93G     0.8991      1.262     0.7774     0.9143         41        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.767      0.685      0.749      0.487      0.764      0.673       0.74      0.433\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    481/500      3.72G     0.8979       1.26     0.7758     0.9141        121        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.766      0.685      0.749      0.486      0.764      0.673      0.739      0.433\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    482/500      4.03G      0.896      1.257     0.7714     0.9133         56        256: 100%|██████████| 605/605 [06:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.766      0.685      0.749      0.486      0.764      0.674      0.739      0.433\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    483/500       4.2G      0.895      1.254     0.7692     0.9125         56        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.766      0.685      0.748      0.486      0.766      0.672      0.739      0.432\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    484/500      3.88G      0.893      1.251     0.7667     0.9117        134        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.766      0.685      0.748      0.486      0.766      0.672      0.739      0.432\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    485/500      3.79G     0.8933      1.248     0.7656     0.9116         52        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.765      0.685      0.748      0.485      0.764      0.673      0.739      0.432\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    486/500       4.4G     0.8917      1.246     0.7643     0.9113        138        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.765      0.685      0.747      0.485      0.764      0.673      0.738      0.432\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    487/500      4.07G     0.8888      1.244     0.7598     0.9105         62        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.765      0.685      0.747      0.484      0.764      0.673      0.738      0.432\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    488/500      4.11G     0.8877      1.241     0.7576     0.9098        148        256: 100%|██████████| 605/605 [05:4\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.765      0.685      0.747      0.484      0.763      0.673      0.738      0.431\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    489/500      3.56G     0.8873       1.24     0.7548     0.9097         85        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.765      0.685      0.746      0.484      0.763      0.673      0.737      0.431\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    490/500       4.2G     0.8854      1.236     0.7535      0.909        108        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.766      0.684      0.746      0.483      0.763      0.672      0.737      0.431\n",
+      "Closing dataloader mosaic\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    491/500      3.92G     0.8837      1.235     0.7494     0.9085         79        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.765      0.684      0.746      0.483      0.763      0.672      0.736       0.43\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    492/500      3.99G      0.882      1.229     0.7482     0.9079         69        256: 100%|██████████| 605/605 [06:0\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.765      0.684      0.745      0.483      0.764      0.672      0.736       0.43\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    493/500      3.92G     0.8814      1.229     0.7454     0.9076         66        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.764      0.684      0.745      0.482      0.763      0.672      0.736       0.43\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    494/500      3.78G     0.8798      1.226     0.7435     0.9081         76        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.764      0.684      0.745      0.482      0.763      0.672      0.736       0.43\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    495/500       3.9G     0.8783      1.226     0.7407      0.907         85        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.763      0.684      0.744      0.482      0.763      0.671      0.735      0.429\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    496/500      4.37G     0.8759       1.22     0.7371     0.9058        107        256: 100%|██████████| 605/605 [08:1\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.763      0.684      0.744      0.481      0.762      0.672      0.735      0.429\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    497/500      4.07G     0.8747       1.22     0.7354     0.9052        120        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.762      0.685      0.744      0.481      0.762      0.672      0.735      0.429\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    498/500      4.18G     0.8748      1.219     0.7338     0.9055         53        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.762      0.685      0.743      0.481      0.761      0.673      0.735      0.429\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    499/500      3.93G     0.8731      1.217     0.7325     0.9053         69        256: 100%|██████████| 605/605 [05:5\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.762      0.685      0.743       0.48      0.761      0.673      0.734      0.428\n",
+      "\n",
+      "      Epoch    GPU_mem   box_loss   seg_loss   cls_loss   dfl_loss  Instances       Size\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "    500/500      3.94G     0.8719      1.215      0.729     0.9046         83        256: 100%|██████████| 605/605 [05:3\n",
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.761      0.686      0.743       0.48       0.76      0.673      0.734      0.428\n",
+      "\n",
+      "498 epochs completed in 64.826 hours.\n",
+      "Optimizer stripped from /home/omran/yolov8s-seg_data_v34/weights/last.pt, 23.9MB\n",
+      "Optimizer stripped from /home/omran/yolov8s-seg_data_v34/weights/best.pt, 23.9MB\n",
+      "\n",
+      "Validating /home/omran/yolov8s-seg_data_v34/weights/best.pt...\n",
+      "Ultralytics 8.3.24 🚀 Python-3.10.6 torch-2.5.0+cu124 CUDA:0 (NVIDIA GeForce RTX 3060 Laptop GPU, 6144MiB)\n",
+      "YOLOv8s-seg summary (fused): 195 layers, 11,779,987 parameters, 0 gradients, 42.4 GFLOPs\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95)     Mask(P          R      mAP5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   all       8363     117177      0.779      0.704      0.789      0.528      0.776      0.692      0.778      0.467\n",
+      "Speed: 0.1ms preprocess, 1.1ms inference, 0.0ms loss, 1.5ms postprocess per image\n",
+      "Results saved to \u001b[1m/home/omran/yolov8s-seg_data_v34\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# For testing purposes the fraction argument can be used to train on a subset of the data\n",
+    "FRACTION = 1.0\n",
+    "\n",
+    "# Setting the starting model\n",
+    "MODEL = 'yolov8s-seg.pt'\n",
+    "\n",
+    "# Setting the project name\n",
+    "PROJECT = '/'\n",
+    "\n",
+    "# Load the arguments from YAML\n",
+    "ARGS_FN = 'args_500e_tuned.yaml'\n",
+    "with open(ARGS_FN, 'r') as f:\n",
+    "    args = yaml.safe_load(f)\n",
+    "\n",
+    "# Generate a name for the training session\n",
+    "name = f'{os.getcwd()}/{MODEL}_data_{data_choice}'\n",
+    "name = name.replace('.pt', '')\n",
+    "\n",
+    "# Prompt the user for input\n",
+    "choice = input(\"Do you want to start or resume training? Enter 'new' for new training or 'resume' to resume training: \")\n",
+    "\n",
+    "# Process the user input\n",
+    "if choice.lower() == 'new':\n",
+    "    print(\"\\nStarting new training...\\n\")\n",
+    "\n",
+    "    # Load the model\n",
+    "    model = YOLO(MODEL)\n",
+    "\n",
+    "    # Train the model\n",
+    "    results = model.train(data=YAML, fraction=FRACTION, project=PROJECT, name=name,device=device, **args)\n",
+    "\n",
+    "elif choice.lower() == 'resume':\n",
+    "    print(\"Resuming training...\")\n",
+    "\n",
+    "    # Load the model\n",
+    "    modelwpath = f'{PROJECT}/{name}/weights/last.pt'\n",
+    "    print(f'Loading model from {modelwpath}')\n",
+    "    model = YOLO(modelwpath)\n",
+    "\n",
+    "    # Resume training\n",
+    "    results = model.train(resume=True)\n",
+    "\n",
+    "else:\n",
+    "    print(\"Invalid input.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "w_okUeo51HLw"
+   },
+   "outputs": [],
+   "source": [
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
# What does this PR do?

This PR adds the YOLOv8 segmentation  model that was trained locally for 500 epochs on the dataset v3. Dataset v3 is documented on the main readme page.

It also add documentation for the notebook that was used to train the model 

![image](https://github.com/user-attachments/assets/19b32de7-baf7-4611-a607-4020c175ea89)
